### PR TITLE
Fix issues when connecting to PS 2018

### DIFF
--- a/Delcam.ProductInterface.PowerSHAPE.Test/AutomationTest.cs
+++ b/Delcam.ProductInterface.PowerSHAPE.Test/AutomationTest.cs
@@ -37,7 +37,7 @@ namespace Autodesk.ProductInterface.PowerSHAPETest
 
         public AutomationTest()
         {
-            // Initialise PowerSHAPE
+            //Initialise PowerSHAPE
             if (_powerSHAPE == null)
             {
                 _powerSHAPE = new PSAutomation(InstanceReuse.UseExistingInstance, Modes.PShapeMode);
@@ -393,7 +393,125 @@ namespace Autodesk.ProductInterface.PowerSHAPETest
         }
 
         [Test]
-        [Ignore("")]
+        public void UseExistingInstance_WhenUsing18NotationWithoutSpecifyingMaximumVersion()
+        {
+            var versionUnderTest = _powerSHAPE.Version;
+            var twenty18 = new PSAutomation(InstanceReuse.UseExistingInstance, new Version("18.1.0"));
+            Assert.That(twenty18.Version.Major, Is.EqualTo(18));
+            twenty18.Quit();
+
+            // Ensure that the version under test is properly registered as the current version so other tests carry on ok...
+            var testVersion = new PSAutomation(InstanceReuse.CreateNewInstance, versionUnderTest);
+            testVersion.Quit();
+        }
+
+        [Test]
+        public void UseExistingInstance_WhenUsing2018NotationWithoutSpecifyingMaximumVersion()
+        {
+            var versionUnderTest = _powerSHAPE.Version;
+            var twenty18 = new PSAutomation(InstanceReuse.UseExistingInstance, new Version("2018.0.0"));
+            Assert.That(twenty18.Version.Major, Is.EqualTo(2018));
+            twenty18.Quit();
+
+            // Ensure that the version under test is properly registered as the current version so other tests carry on ok...
+            var testVersion = new PSAutomation(InstanceReuse.CreateNewInstance, versionUnderTest);
+            testVersion.Quit();
+        }
+
+        [Test]
+        public void UseExistingInstance_WhenUsing2018NotationWithoutSpecifyingMaximumVersion_And_Build()
+        {
+            var versionUnderTest = _powerSHAPE.Version;
+            var twenty18 = new PSAutomation(InstanceReuse.UseExistingInstance, new Version("2018.0"));
+            Assert.That(twenty18.Version.Major, Is.EqualTo(2018));
+            twenty18.Quit();
+
+            // Ensure that the version under test is properly registered as the current version so other tests carry on ok...
+            var testVersion = new PSAutomation(InstanceReuse.CreateNewInstance, versionUnderTest);
+            testVersion.Quit();
+        }
+
+        [Test]
+        public void CreateSingleInstance_WhenUsing2018NotationWithoutSpecifyingMaximumVersion_And_Build()
+        {
+            var versionUnderTest = _powerSHAPE.Version;
+            var twenty18 = new PSAutomation(InstanceReuse.CreateSingleInstance, new Version("2018.0"));
+            Assert.That(twenty18.Version.Major, Is.EqualTo(18));
+            twenty18.Quit();
+
+            // Ensure that the version under test is properly registered as the current version so other tests carry on ok...
+            var testVersion = new PSAutomation(InstanceReuse.CreateNewInstance, versionUnderTest);
+            testVersion.Quit();
+        }
+
+        [Test]
+        public void CreateSingleInstance_WhenUsing2018NotationWithoutSpecifyingMaximumVersion()
+        {
+            var versionUnderTest = _powerSHAPE.Version;
+            var twenty18 = new PSAutomation(InstanceReuse.CreateSingleInstance, new Version("2018.0.0"));
+            Assert.That(twenty18.Version.Major, Is.EqualTo(18));
+            twenty18.Quit();
+
+            // Ensure that the version under test is properly registered as the current version so other tests carry on ok...
+            var testVersion = new PSAutomation(InstanceReuse.CreateNewInstance, versionUnderTest);
+            testVersion.Quit();
+        }
+
+        [Test]
+        public void CreateSingleInstance_WhenUsing18NotationWithoutSpecifyingMaximumVersion()
+        {
+            var versionUnderTest = _powerSHAPE.Version;
+            var twenty18 = new PSAutomation(InstanceReuse.CreateSingleInstance, new Version("18.1.0"));
+            Assert.That(twenty18.Version.Major, Is.EqualTo(18));
+            twenty18.Quit();
+
+            // Ensure that the version under test is properly registered as the current version so other tests carry on ok...
+            var testVersion = new PSAutomation(InstanceReuse.CreateNewInstance, versionUnderTest);
+            testVersion.Quit();
+        }
+
+
+        [Test]
+        public void CreateNewInstance_WhenUsing18NotationWithoutSpecifyingMaximumVersion()
+        {
+            var versionUnderTest = _powerSHAPE.Version;
+            var twenty18 = new PSAutomation(InstanceReuse.CreateNewInstance, new Version("18.1.0"));
+            Assert.That(twenty18.Version.Major, Is.EqualTo(18));
+            twenty18.Quit();
+
+            // Ensure that the version under test is properly registered as the current version so other tests carry on ok...
+            var testVersion = new PSAutomation(InstanceReuse.CreateNewInstance, versionUnderTest);
+            testVersion.Quit();
+        }
+
+
+        [Test]
+        public void CreateNewInstance_WhenUsing2018NotationWithoutSpecifyingMaximumVersion_And_Build()
+        {
+            var versionUnderTest = _powerSHAPE.Version;
+            var twenty18 = new PSAutomation(InstanceReuse.CreateNewInstance, new Version("2018.0"));
+            Assert.That(twenty18.Version.Major, Is.EqualTo(18));
+            twenty18.Quit();
+
+            // Ensure that the version under test is properly registered as the current version so other tests carry on ok...
+            var testVersion = new PSAutomation(InstanceReuse.CreateNewInstance, versionUnderTest);
+            testVersion.Quit();
+        }
+
+        [Test]
+        public void CreateNewInstance_WhenUsing2018NotationWithoutSpecifyingMaximumVersion()
+        {
+            var versionUnderTest = _powerSHAPE.Version;
+            var twenty18 = new PSAutomation(InstanceReuse.CreateNewInstance, new Version("2018.0.0"));
+            Assert.That(twenty18.Version.Major, Is.EqualTo(18));
+            twenty18.Quit();
+
+            // Ensure that the version under test is properly registered as the current version so other tests carry on ok...
+            var testVersion = new PSAutomation(InstanceReuse.CreateNewInstance, versionUnderTest);
+            testVersion.Quit();
+        }
+
+        [Test]
         public void MultipleVersionsTest_WhenUsing2018Notation()
         {
             var versionUnderTest = _powerSHAPE.Version;
@@ -410,7 +528,6 @@ namespace Autodesk.ProductInterface.PowerSHAPETest
         }
 
         [Test]
-        [Ignore("")]
         public void MultipleVersionsTest_WhenUsing18Notation()
         {
             var versionUnderTest = _powerSHAPE.Version;

--- a/Delcam.ProductInterface.PowerShape/PSAutomation/PSAutomation.cs
+++ b/Delcam.ProductInterface.PowerShape/PSAutomation/PSAutomation.cs
@@ -239,7 +239,7 @@ namespace Autodesk.ProductInterface.PowerSHAPE
                     if (maximumVersion == null)
                     {
                         var _with1 = version;
-                        if (_powerSHAPE.Version != string.Format("{0:#}{1:0}{2:00}", _with1.Major, _with1.Minor, _with1.Build))
+                        if (_powerSHAPE.Version.ToString() != string.Format("{0:#}{1:0}{2:00}", _with1.Major, _with1.Minor, _with1.Build))
                         {
                             throw new Exception("Incorrect version found");
                         }
@@ -378,30 +378,27 @@ namespace Autodesk.ProductInterface.PowerSHAPE
 
         private void TweakVersionNumbersTo2018(ref Version tweakedVersion, ref Version tweakedMaximumVersion)
         {
-            if (tweakedVersion != null && tweakedVersion.Major >= 18 && tweakedVersion.Major < 2018)
+            if (IsItAVersionEqualOrAbove2018(tweakedVersion))
             {
-                tweakedVersion = new Version(2000 + tweakedVersion.Major, 0, 0);
-            }
-            if (tweakedMaximumVersion != null && tweakedMaximumVersion.Major >= 18 && tweakedMaximumVersion.Major < 2018)
-            {
-                tweakedMaximumVersion = new Version(2000 + tweakedMaximumVersion.Major, 0, 0);
+                // For PS 2018 we can only have one version installed, so any 2018 is ok
+                tweakedVersion = new Version(2018, 0, 0);
+                tweakedMaximumVersion = new Version(2018, 99, 99);
             }
         }
 
         private void TweakVersionNumbersFrom2018(ref Version tweakedVersion, ref Version tweakedMaximumVersion)
         {
-            if (tweakedVersion != null && tweakedVersion.Major >= 2018)
+            if (IsItAVersionEqualOrAbove2018(tweakedVersion))
             {
-                tweakedVersion = new Version(tweakedVersion.Major - 2000,
-                                             tweakedVersion.Minor == 0 ? 1 : tweakedVersion.Minor,
-                                             tweakedVersion.Build);
+                // For PS 2018 we can only have one version installed, so any 2018 is ok
+                tweakedVersion = new Version(18, 0, 0);
+                tweakedMaximumVersion = new Version(18, 99, 99);
             }
-            if (tweakedMaximumVersion != null && tweakedMaximumVersion.Major >= 2018)
-            {
-                tweakedMaximumVersion = new Version(tweakedMaximumVersion.Major - 2000,
-                                                    tweakedMaximumVersion.Minor == 0 ? 1 : tweakedMaximumVersion.Minor,
-                                                    tweakedMaximumVersion.Build);
-            }
+        }
+
+        private bool IsItAVersionEqualOrAbove2018(Version version)
+        {
+            return version != null && (version.Major >= 18 || version.Major >= 2018);
         }
 
         /// <summary>

--- a/Delcam.ProductInterface/Automation.cs
+++ b/Delcam.ProductInterface/Automation.cs
@@ -394,7 +394,7 @@ namespace Autodesk.ProductInterface
                             {
                                 // We are being picky about a version number so check that it is the correct version
                                 var _with2 = version;
-                                if (application.Version !=
+                                if (application.Version.ToString() !=
                                     string.Format("{0:#}{1:0}{2:00}", _with2.Major, _with2.Minor, _with2.Build))
                                 {
                                     process.Kill();


### PR DESCRIPTION
Fixing the following issues:
- CreateNewInstance won't work if you don't specify the maximum version that you want to use
- CreateNewInstance won't work using the following version formats "2018.0" or "2018.0.0"
- Updated Unit tests to ensure that there were no issues connecting to PS 2018 no matter if:
1. Using CreateNewInstance, UseExistingInstance or CreateSingleInstance
2. Maximum version was not specified
3. version format was "2018.0.0" or, for instance,"18.1.0"