### PR TITLE
Added code to get the process id of the instance of PowerShape

### DIFF
--- a/Delcam.ProductInterface.PowerSHAPE.Test/AutomationTest.cs
+++ b/Delcam.ProductInterface.PowerSHAPE.Test/AutomationTest.cs
@@ -590,6 +590,17 @@ namespace Autodesk.ProductInterface.PowerSHAPETest
             testVersion.Quit();
         }
 
+        [Ignore("Fail on Build Server")]
+        [Test]
+        public void ProcessIdTest()
+        {
+            var singleInstance = new PSAutomation(InstanceReuse.CreateNewInstance);
+            var newProcessId = singleInstance.ProcessId;
+            singleInstance.Quit();
+
+            Assert.That(newProcessId, Is.Not.EqualTo(_powerSHAPE.ProcessId));
+        }
+
         /// <summary>
         /// Test for DrawingTolerance
         /// </summary>

--- a/Delcam.ProductInterface.PowerShape/PSAutomation/PSAutomation.cs
+++ b/Delcam.ProductInterface.PowerShape/PSAutomation/PSAutomation.cs
@@ -1556,6 +1556,11 @@ namespace Autodesk.ProductInterface.PowerSHAPE
         }
 
         /// <summary>
+        /// Process id of the application instance.
+        /// </summary>
+        public override int ProcessId => int.Parse(DoCommandEx("app.pid").ToString());
+
+        /// <summary>
         /// The class Id to use based on the Application Mode selected through the constructor.
         /// </summary>
         /// <returns></returns>

--- a/Delcam.ProductInterface/Automation.cs
+++ b/Delcam.ProductInterface/Automation.cs
@@ -168,23 +168,7 @@ namespace Autodesk.ProductInterface
         /// <summary>
         /// Process id of the application instance.
         /// </summary>
-        public virtual int ProcessId
-        {
-            get
-            {
-                if (_processId == 0)
-                {
-                    // Need to determine process id
-                    foreach (Process process in Process.GetProcessesByName(ExecutableName))
-                    {
-                        _processId = process.Id;
-                        break; // TODO: might not be correct. Was : Exit For
-                    }
-                }
-
-                return _processId;
-            }
-        }
+        public abstract int ProcessId { get; }
 
         /// <summary>
         /// Handle of the main window of this application instance.


### PR DESCRIPTION
This has no immediate benefit but if we ever add a function to get the list of PowerShape objects from the Rot (which currently fails to work) then it will be necessary that this works correctly.