### PR TITLE
Fix outputting closed Polylines to Duct Picture files.

### DIFF
--- a/Delcam.Geometry.Test/GeometricEntities/Polyline.Test.cs
+++ b/Delcam.Geometry.Test/GeometricEntities/Polyline.Test.cs
@@ -58,6 +58,33 @@ namespace Autodesk.Geometry.Test.GeometricEntities
         }
 
         [Test]
+        public void WriteClosedPolylineTest()
+        {
+            FileSystem.File tempFile = FileSystem.File.CreateTemporaryFile("pic");
+            List<Point> points = new List<Point>();
+            points.Add(new Point(0, 0, 0));
+            points.Add(new Point(10, 5, 2));
+            points.Add(new Point(20, 9, 5));
+
+            Polyline line = new Polyline(points);
+
+            line.WriteToDUCTPictureFile(tempFile);
+
+            Polyline newline = Polyline.ReadFromDUCTPictureFile(tempFile).Single();
+            // Assert that the polyline read from the file is open
+            Assert.IsFalse(newline.IsClosed);
+
+            // Close the polyline and write again
+            line.IsClosed = true;
+
+            line.WriteToDUCTPictureFile(tempFile);
+
+            newline = Polyline.ReadFromDUCTPictureFile(tempFile).Single();
+            // Assert that the polyline read from the file is closed
+            Assert.IsTrue(newline.IsClosed);
+        }
+
+        [Test]
         public void
             WhenDensifyPolylineWithOneSegment_GivenLengthIsExactMultipleOfMaxInput_ThenEachNewSegmentsShouldBeInThatLength()
         {

--- a/Delcam.Geometry.Test/GeometricEntities/Polyline.Test.cs
+++ b/Delcam.Geometry.Test/GeometricEntities/Polyline.Test.cs
@@ -82,6 +82,7 @@ namespace Autodesk.Geometry.Test.GeometricEntities
             newline = Polyline.ReadFromDUCTPictureFile(tempFile).Single();
             // Assert that the polyline read from the file is closed
             Assert.IsTrue(newline.IsClosed);
+            tempFile.Delete();
         }
 
         [Test]

--- a/Delcam.Geometry/GeometricEntities/Polyline.cs
+++ b/Delcam.Geometry/GeometricEntities/Polyline.cs
@@ -574,6 +574,8 @@ namespace Autodesk.Geometry
         {
             try
             {
+                // If the polyline is closed the last point needs to be duplicated so add 1 to the count in that case.
+                var trueCount = Count + (IsClosed ? 1 : 0);
                 // Delete the file if it already exists
                 file.Delete();
 
@@ -597,7 +599,7 @@ namespace Autodesk.Geometry
 
                 // Write integer data
                 string integerLine = "";
-                if (Count > 1000000)
+                if (trueCount > 1000000)
                 {
                     integerLine += " " + GetField(4, 3) + GetField(3, 3) + GetField(-1, 11) + GetField(1, 11) +
                                    GetField(Count, 11) + GetField(-2, 6) + GetField(2, 6) + GetField(0, 6) + GetField(0, 6) +
@@ -620,14 +622,14 @@ namespace Autodesk.Geometry
                 // Write instruction codes
                 int instructionCode = GetInstructionCode(1, 0, 0, 0, 0, 0);
                 string instructionCodeString = "";
-                if (Count > 1000000)
+                if (trueCount > 1000000)
                 {
-                    instructionCodeString = " " + GetField(instructionCode, 11) + " " + GetField(Count, 11) + Constants.vbNewLine;
+                    instructionCodeString = " " + GetField(instructionCode, 11) + " " + GetField(trueCount, 11) + Constants.vbNewLine;
                     pictureData.Append(instructionCodeString);
                 }
                 else
                 {
-                    instructionCodeString = " " + GetField(instructionCode, 11) + " " + GetField(Count, 6) + Constants.vbNewLine;
+                    instructionCodeString = " " + GetField(instructionCode, 11) + " " + GetField(trueCount, 6) + Constants.vbNewLine;
                     pictureData.Append(instructionCodeString);
                 }
 


### PR DESCRIPTION
When outputting closed polylines to Duct .pic files the first point is duplicated at the end of the pic file but the count is not incremented so on import that last point is ignored and thus it is marked as open.

This fixes this by creating a trueCount variable that is incremented by 1 if the polyline is closed.

Signed-off-by: Jon Sturm <JSturm@programmingplus.com>