### PR TITLE
Crash on create single instance

### DIFF
--- a/Delcam.ProductInterface/Automation.cs
+++ b/Delcam.ProductInterface/Automation.cs
@@ -233,6 +233,11 @@ namespace Autodesk.ProductInterface
                 processesRunning = Process.GetProcessesByName(name).Length > 0;
             }
 
+            if (Process.GetProcessesByName(name).Length > 0)
+            {
+                throw new Exception("Failed to close all running instances of " + name);
+            }
+
             Console.WriteLine("Done");
         }
 

--- a/Delcam.ProductInterface/Automation.cs
+++ b/Delcam.ProductInterface/Automation.cs
@@ -218,14 +218,18 @@ namespace Autodesk.ProductInterface
             // Find all the processes with the passed in name and kill them
             foreach (Process process in Process.GetProcessesByName(name))
             {
-                try
+                var startTime = DateTime.UtcNow;
+                while (process.HasExited == false && DateTime.UtcNow - startTime < TimeSpan.FromSeconds(10))
                 {
-                    process.Kill();
+                    try
+                    {
+                        process.Kill();
+                    }
+                    catch
+                    {
+                    }
+                    Thread.Sleep(100);
                 }
-                catch
-                {
-                }
-                process.WaitForExit(10000);
                 if (process.HasExited == false)
                 {
                     throw new Exception("Failed to close all instances of " + name);

--- a/Delcam.ProductInterface/Automation.cs
+++ b/Delcam.ProductInterface/Automation.cs
@@ -215,11 +215,11 @@ namespace Autodesk.ProductInterface
         {
             Console.WriteLine("Closing all instances...");
 
-            // Find all the processes with the passed in name and kill them
-            foreach (Process process in Process.GetProcessesByName(name))
+            var processesRunning = true;
+            var startTime = DateTime.UtcNow;
+            while (processesRunning && DateTime.UtcNow - startTime < TimeSpan.FromSeconds(10))
             {
-                var startTime = DateTime.UtcNow;
-                while (process.HasExited == false && DateTime.UtcNow - startTime < TimeSpan.FromSeconds(10))
+                foreach (Process process in Process.GetProcessesByName(name))
                 {
                     try
                     {
@@ -228,13 +228,11 @@ namespace Autodesk.ProductInterface
                     catch
                     {
                     }
-                    Thread.Sleep(100);
                 }
-                if (process.HasExited == false)
-                {
-                    throw new Exception("Failed to close all instances of " + name);
-                }
+
+                processesRunning = Process.GetProcessesByName(name).Length > 0;
             }
+
             Console.WriteLine("Done");
         }
 


### PR DESCRIPTION
When a process is closing it seems that if you try and access the details of it you can get errors about "Access Denied".  To avoid this I continually read the list of processes to see if the requested process has finished.