### PR TITLE
Added Function to undraw all entities

### DIFF
--- a/Delcam.ProductInterface.PowerMILL.Test/PMAutomationTest.cs
+++ b/Delcam.ProductInterface.PowerMILL.Test/PMAutomationTest.cs
@@ -253,9 +253,9 @@ namespace Autodesk.ProductInterface.PowerMILLTest
         {            
             MyTestInitialize();
             var testPattern = _powerMill.ActiveProject.Patterns.CreatePattern(Files.TestFiles.CurvesFiles);
-            testPattern.IsVisible = true;
+            testPattern.IsVisible = true;            
             _powerMill.UndrawAll();
-            //Assert.False(testPattern.IsVisible);                     
+            Assert.IsTrue(true);
         }
     }
 }

--- a/Delcam.ProductInterface.PowerMILL.Test/PMAutomationTest.cs
+++ b/Delcam.ProductInterface.PowerMILL.Test/PMAutomationTest.cs
@@ -247,5 +247,15 @@ namespace Autodesk.ProductInterface.PowerMILLTest
             //Quit
             automation2.Quit();
         }
+
+        [Test]
+        public void UndrawAllTest()
+        {            
+            MyTestInitialize();
+            var testPattern = _powerMill.ActiveProject.Patterns.CreatePattern(Files.TestFiles.CurvesFiles);
+            testPattern.IsVisible = true;
+            _powerMill.UndrawAll();
+            //Assert.False(testPattern.IsVisible);                     
+        }
     }
 }

--- a/Delcam.ProductInterface.PowerMILL/PMAutomation.cs
+++ b/Delcam.ProductInterface.PowerMILL/PMAutomation.cs
@@ -630,6 +630,13 @@ namespace Autodesk.ProductInterface.PowerMILL
             }
         }
 
+        /// <summary>
+        /// Undraw all Entities.
+        /// </summary>        
+        public void UndrawAll()
+        {            
+            DoCommand("UNDRAW ALL");            
+        }
         #endregion
 
         #region Execute Operations


### PR DESCRIPTION
New function to undraw all entities.

I only have one problem with the test routine. I've found no way to check if an entitie is visible or not. Maybe anyone knows a way to check this.

I also want to add the functionality to undraw entitie groups like all NCPrograms or all Toolpaths as well as single entities themself. At the moment a see three different approaches:

Version 1:
powermill.UndrawAllNCPrograms();			//Undraw all ncprograms

Version 2:
powermill.Undraw(NCProgram);				//Undraw all ncprograms
powermill.Undraw(NCProgram, [PMNCProgram]);	//Undraw NC program [PMNCProgram]

Version 3:
session.NCPrograms.UndrawAll()				//Undraw all ncprograms
session.Boundarys.Undraw([PMNCProgram])		//Undraw NC Program [PMNCProgram]

With Version 2 and Version 3 i would like to introduce a new enum like "EntitieTypes" so you can name the entities you would like to undraw.