### PR TITLE
Debug CreateBlockFromBoundary functions

### DIFF
--- a/Delcam.ProductInterface.PowerMILL.Test/PMEntityTests/PMProjectTests.cs
+++ b/Delcam.ProductInterface.PowerMILL.Test/PMEntityTests/PMProjectTests.cs
@@ -147,6 +147,24 @@ namespace Autodesk.ProductInterface.PowerMILLTest
             Assert.That(boundingBox.MinZ, Is.EqualTo((Autodesk.Geometry.MM)(-30.004846)));
         }
 
+        [Test]
+        public void ExportBlockTest()
+        {            
+            _powerMILL.ActiveProject.Boundaries.CreateBoundary(TestFiles.CurvesFiles);
+            _powerMILL.ActiveProject.Refresh();
+            PMBoundary boundary = _powerMILL.ActiveProject.Boundaries.ActiveItem;
+            var boundingBox = _powerMILL.ActiveProject.CreateBlockFromBoundaryWithLimits(boundary, 0, 100);
+            FileSystem.File file = new FileSystem.File(TestFiles.DIRECTORY + "\\ExportBlock.dmt");
+            _powerMILL.ActiveProject.ExportBlock(file);
+            Assert.That(file.Exists);
+            file.Delete();
+            file = new FileSystem.File(TestFiles.DIRECTORY + "\\ExportBlock.stl");
+            _powerMILL.ActiveProject.ExportBlock(file);
+            Assert.That(file.Exists);
+            file.Delete();
+        }
+
+
         #endregion
     }
 }

--- a/Delcam.ProductInterface.PowerMILL.Test/PMEntityTests/PMProjectTests.cs
+++ b/Delcam.ProductInterface.PowerMILL.Test/PMEntityTests/PMProjectTests.cs
@@ -153,12 +153,12 @@ namespace Autodesk.ProductInterface.PowerMILLTest
             _powerMILL.ActiveProject.Boundaries.CreateBoundary(TestFiles.CurvesFiles);
             _powerMILL.ActiveProject.Refresh();
             PMBoundary boundary = _powerMILL.ActiveProject.Boundaries.ActiveItem;
-            var boundingBox = _powerMILL.ActiveProject.CreateBlockFromBoundaryWithLimits(boundary, 0, 100);
-            FileSystem.File file = new FileSystem.File(TestFiles.DIRECTORY + "\\ExportBlock.dmt");
+            var boundingBox = _powerMILL.ActiveProject.CreateBlockFromBoundaryWithLimits(boundary, 0, 100);            
+            FileSystem.File file = FileSystem.File.CreateTemporaryFile("dmt", false);
             _powerMILL.ActiveProject.ExportBlock(file);
             Assert.That(file.Exists);
-            file.Delete();
-            file = new FileSystem.File(TestFiles.DIRECTORY + "\\ExportBlock.stl");
+            file.Delete();            
+            file = FileSystem.File.CreateTemporaryFile("stl", false);
             _powerMILL.ActiveProject.ExportBlock(file);
             Assert.That(file.Exists);
             file.Delete();

--- a/Delcam.ProductInterface.PowerMILL/Classes/PMProject.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/PMProject.cs
@@ -430,7 +430,10 @@ namespace Autodesk.ProductInterface.PowerMILL
         /// <param name="boundary">The boundary from which to create the block.</param>        
         public BoundingBox CreateBlockFromBoundary(PMBoundary boundary)
         {
-            if (boundary != null)
+            if (boundary == null)
+                throw new ArgumentNullException("boundary", "Boundary not found");
+
+            if (boundary.Exists)
             {
                 _powerMILL.DoCommand("EDIT MODEL ALL DESELECT ALL");
                 _powerMILL.DoCommand(string.Format("ACTIVATE BOUNDARY \"{0}\"", boundary.Name));
@@ -450,8 +453,11 @@ namespace Autodesk.ProductInterface.PowerMILL
         /// <param name="ZMin">Set the minimum Z value of the Block</param>
         /// <param name="ZMax">Set the maximum Z value of the Block</param>
         public BoundingBox CreateBlockFromBoundaryWithLimits(PMBoundary boundary, double ZMin, double ZMax)
-        {            
-            if (boundary != null)
+        {
+            if (boundary == null)
+                throw new ArgumentNullException("boundary", "Boundary not found");
+
+            if (boundary.Exists)
             {
                 _powerMILL.DoCommand("EDIT MODEL ALL DESELECT ALL");
                 _powerMILL.DoCommand(string.Format("ACTIVATE BOUNDARY \"{0}\"", boundary.Name));
@@ -474,7 +480,11 @@ namespace Autodesk.ProductInterface.PowerMILL
             if (file.Extension.ToLower() == "dmt" || file.Extension.ToLower() == "stl")
             {
                 _powerMILL.DoCommand("EXPORT BLOCK ; '" + file + "' YES");
-            }            
+            }
+            else
+            {
+                throw new Exception("Only .dmt and .stl supported");
+            }
         }
 
         /// <summary>

--- a/Delcam.ProductInterface.PowerMILL/Classes/PMProject.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/PMProject.cs
@@ -429,13 +429,16 @@ namespace Autodesk.ProductInterface.PowerMILL
         /// </summary>
         /// <param name="boundary">The boundary from which to create the block.</param>        
         public BoundingBox CreateBlockFromBoundary(PMBoundary boundary)
-        {            
-            _powerMILL.DoCommand("EDIT MODEL ALL DESELECT ALL");
-            _powerMILL.DoCommand(string.Format("ACTIVATE BOUNDARY \"{0}\"", boundary.Name));
-            _powerMILL.DoCommand("EDIT BLOCKTYPE BOUNDARY");
-            _powerMILL.DoCommand("EDIT BLOCK RESETLIMIT 0");
-            _powerMILL.DoCommand("EDIT BLOCK RESET");
-            _powerMILL.DoCommand("BLOCK ACCEPT");
+        {
+            if (boundary != null)
+            {
+                _powerMILL.DoCommand("EDIT MODEL ALL DESELECT ALL");
+                _powerMILL.DoCommand(string.Format("ACTIVATE BOUNDARY \"{0}\"", boundary.Name));
+                _powerMILL.DoCommand("EDIT BLOCKTYPE BOUNDARY");
+                _powerMILL.DoCommand("EDIT BLOCK RESETLIMIT 0");
+                _powerMILL.DoCommand("EDIT BLOCK RESET");
+                _powerMILL.DoCommand("BLOCK ACCEPT");
+            }
             BoundingBox boundingBox = GetBlockLimits();            
             return boundingBox;
         }
@@ -447,17 +450,31 @@ namespace Autodesk.ProductInterface.PowerMILL
         /// <param name="ZMin">Set the minimum Z value of the Block</param>
         /// <param name="ZMax">Set the maximum Z value of the Block</param>
         public BoundingBox CreateBlockFromBoundaryWithLimits(PMBoundary boundary, double ZMin, double ZMax)
-        {
-            _powerMILL.DoCommand("EDIT MODEL ALL DESELECT ALL");
-            _powerMILL.DoCommand(string.Format("ACTIVATE BOUNDARY \"{0}\"", boundary.Name));
-            _powerMILL.DoCommand("EDIT BLOCKTYPE BOUNDARY");
-            _powerMILL.DoCommand("EDIT BLOCK RESETLIMIT 0");
-            _powerMILL.DoCommand("EDIT BLOCK RESET");
-            _powerMILL.DoCommand(string.Format("EDIT BLOCK ZMIN \"{0}\"", ZMin));
-            _powerMILL.DoCommand(string.Format("EDIT BLOCK ZMAX \"{0}\"", ZMax));            
-            _powerMILL.DoCommand("BLOCK ACCEPT");
+        {            
+            if (boundary != null)
+            {
+                _powerMILL.DoCommand("EDIT MODEL ALL DESELECT ALL");
+                _powerMILL.DoCommand(string.Format("ACTIVATE BOUNDARY \"{0}\"", boundary.Name));
+                _powerMILL.DoCommand("EDIT BLOCKTYPE BOUNDARY");
+                _powerMILL.DoCommand("EDIT BLOCK RESETLIMIT 0");                
+                _powerMILL.DoCommand(string.Format("EDIT BLOCK ZMIN \"{0}\"", ZMin));
+                _powerMILL.DoCommand(string.Format("EDIT BLOCK ZMAX \"{0}\"", ZMax));
+                _powerMILL.DoCommand("BLOCK ACCEPT");                
+            }
             BoundingBox boundingBox = GetBlockLimits();
             return boundingBox;
+        }
+
+        /// <summary>
+        /// This operation exports the Block as DMT file 
+        /// </summary>
+        /// <param name="file">The file where to save the block (.dmt and .stl only)</param>        
+        public void ExportBlock(Autodesk.FileSystem.File file)
+        {                      
+            if (file.Extension.ToLower() == "dmt" || file.Extension.ToLower() == "stl")
+            {
+                _powerMILL.DoCommand("EXPORT BLOCK ; '" + file + "' YES");
+            }            
         }
 
         /// <summary>

--- a/Delcam.ProductInterface.PowerMILL/Classes/PMProject.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/PMProject.cs
@@ -430,18 +430,15 @@ namespace Autodesk.ProductInterface.PowerMILL
         /// <param name="boundary">The boundary from which to create the block.</param>        
         public BoundingBox CreateBlockFromBoundary(PMBoundary boundary)
         {
-            if (boundary == null)
+            if (boundary == null || !boundary.Exists)
                 throw new ArgumentNullException("boundary", "Boundary not found");
-
-            if (boundary.Exists)
-            {
-                _powerMILL.DoCommand("EDIT MODEL ALL DESELECT ALL");
-                _powerMILL.DoCommand(string.Format("ACTIVATE BOUNDARY \"{0}\"", boundary.Name));
-                _powerMILL.DoCommand("EDIT BLOCKTYPE BOUNDARY");
-                _powerMILL.DoCommand("EDIT BLOCK RESETLIMIT 0");
-                _powerMILL.DoCommand("EDIT BLOCK RESET");
-                _powerMILL.DoCommand("BLOCK ACCEPT");
-            }
+                       
+            _powerMILL.DoCommand("EDIT MODEL ALL DESELECT ALL");
+            _powerMILL.DoCommand(string.Format("ACTIVATE BOUNDARY \"{0}\"", boundary.Name));
+            _powerMILL.DoCommand("EDIT BLOCKTYPE BOUNDARY");
+            _powerMILL.DoCommand("EDIT BLOCK RESETLIMIT 0");
+            _powerMILL.DoCommand("EDIT BLOCK RESET");
+            _powerMILL.DoCommand("BLOCK ACCEPT");            
             BoundingBox boundingBox = GetBlockLimits();            
             return boundingBox;
         }
@@ -454,19 +451,16 @@ namespace Autodesk.ProductInterface.PowerMILL
         /// <param name="ZMax">Set the maximum Z value of the Block</param>
         public BoundingBox CreateBlockFromBoundaryWithLimits(PMBoundary boundary, double ZMin, double ZMax)
         {
-            if (boundary == null)
+            if (boundary == null || !boundary.Exists)
                 throw new ArgumentNullException("boundary", "Boundary not found");
-
-            if (boundary.Exists)
-            {
-                _powerMILL.DoCommand("EDIT MODEL ALL DESELECT ALL");
-                _powerMILL.DoCommand(string.Format("ACTIVATE BOUNDARY \"{0}\"", boundary.Name));
-                _powerMILL.DoCommand("EDIT BLOCKTYPE BOUNDARY");
-                _powerMILL.DoCommand("EDIT BLOCK RESETLIMIT 0");                
-                _powerMILL.DoCommand(string.Format("EDIT BLOCK ZMIN \"{0}\"", ZMin));
-                _powerMILL.DoCommand(string.Format("EDIT BLOCK ZMAX \"{0}\"", ZMax));
-                _powerMILL.DoCommand("BLOCK ACCEPT");                
-            }
+                       
+            _powerMILL.DoCommand("EDIT MODEL ALL DESELECT ALL");
+            _powerMILL.DoCommand(string.Format("ACTIVATE BOUNDARY \"{0}\"", boundary.Name));
+            _powerMILL.DoCommand("EDIT BLOCKTYPE BOUNDARY");
+            _powerMILL.DoCommand("EDIT BLOCK RESETLIMIT 0");                
+            _powerMILL.DoCommand(string.Format("EDIT BLOCK ZMIN \"{0}\"", ZMin));
+            _powerMILL.DoCommand(string.Format("EDIT BLOCK ZMAX \"{0}\"", ZMax));
+            _powerMILL.DoCommand("BLOCK ACCEPT");           
             BoundingBox boundingBox = GetBlockLimits();
             return boundingBox;
         }


### PR DESCRIPTION
The CreateBlockFromBoundary and CreateBlockFromBoundaryWithLimits functions now checking if the boundary exists before creating the block.

The CreateBlockFromBoundaryWithLimits now doesn't reset the block (isn't needed because we have the ZMin and ZMax)

Added an function to Export the Block as .dmt or .stl file