### PR TITLE
Cache "numer of" variables to reduce API calls

### DIFF
--- a/Delcam.ProductInterface.PowerShape/Entities/Surfaces/PSSurface.cs
+++ b/Delcam.ProductInterface.PowerShape/Entities/Surfaces/PSSurface.cs
@@ -350,8 +350,8 @@ namespace Autodesk.ProductInterface.PowerSHAPE
                 // Populate list if it's empty
                 if (_laterals.Count == 0)
                 {
-	                int cachedNumberOfLaterals = NumberOfLaterals;
-	                for (int i = 1; i <= cachedNumberOfLaterals; i++)
+                    int cachedNumberOfLaterals = NumberOfLaterals;
+                    for (int i = 1; i <= cachedNumberOfLaterals; i++)
                     {
                         PSLateral lateral = new PSLateral(_powerSHAPE, i.ToString(), this);
                         _laterals.Add(lateral);
@@ -374,7 +374,7 @@ namespace Autodesk.ProductInterface.PowerSHAPE
                 // Populate list if it's empty
                 if (_longitudinals.Count == 0)
                 {
-	                int cachedNumberOfLongitudinals = NumberOfLongitudinals;
+                    int cachedNumberOfLongitudinals = NumberOfLongitudinals;
                     for (int i = 1; i <= cachedNumberOfLongitudinals; i++)
                     {
                         PSLongitudinal longitudinal = new PSLongitudinal(_powerSHAPE, i.ToString(), this);
@@ -813,9 +813,9 @@ namespace Autodesk.ProductInterface.PowerSHAPE
             _powerSHAPE.DoCommand("DISTANCE " + length);
             _powerSHAPE.DoCommand("EDIT LIMIT POINT OFF");
 
-			// Reinitialise the internal curve collections to invalidate the cache.
+            // Reinitialise the internal curve collections to invalidate the cache.
             // This will result in API evaluation on next invocation of get accessor
-			_laterals = new PSLateralsCollection(_powerSHAPE, this);
+            _laterals = new PSLateralsCollection(_powerSHAPE, this);
             _longitudinals = new PSLongitudinalsCollection(_powerSHAPE, this);
         }
 

--- a/Delcam.ProductInterface.PowerShape/Entities/Surfaces/PSSurface.cs
+++ b/Delcam.ProductInterface.PowerShape/Entities/Surfaces/PSSurface.cs
@@ -25,7 +25,6 @@ namespace Autodesk.ProductInterface.PowerSHAPE
         private SurfaceTypes? _surfaceType;
         private PSMaterial _material;
         private PSLateralsCollection _laterals;
-
         private PSLongitudinalsCollection _longitudinals;
 
         #endregion
@@ -351,7 +350,8 @@ namespace Autodesk.ProductInterface.PowerSHAPE
                 // Populate list if it's empty
                 if (_laterals.Count == 0)
                 {
-                    for (int i = 1; i <= NumberOfLaterals; i++)
+	                int cachedNumberOfLaterals = NumberOfLaterals;
+	                for (int i = 1; i <= cachedNumberOfLaterals; i++)
                     {
                         PSLateral lateral = new PSLateral(_powerSHAPE, i.ToString(), this);
                         _laterals.Add(lateral);
@@ -374,7 +374,8 @@ namespace Autodesk.ProductInterface.PowerSHAPE
                 // Populate list if it's empty
                 if (_longitudinals.Count == 0)
                 {
-                    for (int i = 1; i <= NumberOfLongitudinals; i++)
+	                int cachedNumberOfLongitudinals = NumberOfLongitudinals;
+                    for (int i = 1; i <= cachedNumberOfLongitudinals; i++)
                     {
                         PSLongitudinal longitudinal = new PSLongitudinal(_powerSHAPE, i.ToString(), this);
                         _longitudinals.Add(longitudinal);
@@ -394,7 +395,8 @@ namespace Autodesk.ProductInterface.PowerSHAPE
             {
                 AbortIfDoesNotExist();
                 List<PSpCurve> allPCurves = new List<PSpCurve>();
-                for (int i = 1; i <= NumberOfPCurves; i++)
+                int cachedNumberOfPCurves = NumberOfPCurves;
+                for (int i = 1; i <= cachedNumberOfPCurves; i++)
                 {
                     string pCurveName = _powerSHAPE.ReadStringValue(Identifier + "[ID " + _id + "].PCURVE[" + i + "]");
                     allPCurves.Add(new PSpCurve(_powerSHAPE, this, pCurveName));
@@ -810,6 +812,11 @@ namespace Autodesk.ProductInterface.PowerSHAPE
             _powerSHAPE.DoCommand("EDGE " + (int)edge);
             _powerSHAPE.DoCommand("DISTANCE " + length);
             _powerSHAPE.DoCommand("EDIT LIMIT POINT OFF");
+
+			// Reinitialise the internal curve collections to invalidate the cache.
+            // This will result in API evaluation on next invocation of get accessor
+			_laterals = new PSLateralsCollection(_powerSHAPE, this);
+            _longitudinals = new PSLongitudinalsCollection(_powerSHAPE, this);
         }
 
         /// <summary>

--- a/Delcam.ProductInterface.PowerShape/Entities/Wireframe/PSSurfaceCurve.cs
+++ b/Delcam.ProductInterface.PowerShape/Entities/Wireframe/PSSurfaceCurve.cs
@@ -131,7 +131,8 @@ namespace Autodesk.ProductInterface.PowerSHAPE
                 AbortIfDoesNotExist();
 
                 List<Point> surfaceCurvePoints = new List<Point>();
-                for (int index = 1; index <= NumberPoints; index++)
+                int cachedNumberPoints = NumberPoints;
+                for (int index = 1; index <= cachedNumberPoints; index++)
                 {
                     double[] coordinates = null;
                     coordinates = _powerSHAPE.DoCommandEx(Identifier + "[" + Name + "].POINT[" + index + "]") as double[];

--- a/Delcam.ProductInterface.PowerShape/Entities/Wireframe/PSWireframe.cs
+++ b/Delcam.ProductInterface.PowerShape/Entities/Wireframe/PSWireframe.cs
@@ -93,7 +93,8 @@ namespace Autodesk.ProductInterface.PowerSHAPE
                 AbortIfDoesNotExist();
 
                 List<Point> wireframePoints = new List<Point>();
-                for (int index = 1; index <= NumberPoints; index++)
+                int cachedNumberPoints = NumberPoints;
+                for (int index = 1; index <= cachedNumberPoints; index++)
                 {
                     double[] coordinates = null;
                     coordinates = _powerSHAPE.DoCommandEx(Identifier + "[ID " + _id + "].POINT[" + index + "]") as double[];


### PR DESCRIPTION
These changes look to cache the "NumberOf" properties for use during immutable loops, thus reducing API called behind the "get" accessors. There is also a change to nullify the internal curve collection caches after surface extensions to force for re-evaluation on the next "get".