### PR TITLE
MAKE-50 Reduce usage of DoCommandEx or ExecuteEx in ProductInterfacePowerMILL

### DIFF
--- a/Delcam.ProductInterface.PowerMILL/Classes/Boundary/PMBoundaryEntityFactory.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/Boundary/PMBoundaryEntityFactory.cs
@@ -26,7 +26,7 @@ namespace Autodesk.ProductInterface.PowerMILL
         internal static PMBoundary CreateEntity(PMAutomation powerMILL, string name)
         {
             switch (
-                powerMILL.DoCommandEx("PRINT PAR TERSE \"entity('boundary', '" + name + "').type\"").ToString().Trim())
+                powerMILL.GetPowerMillEntityParameter("boundary", name ,"type").Trim())
             {
                 case "block":
                     return new PMBoundaryBlock(powerMILL, name);

--- a/Delcam.ProductInterface.PowerMILL/Classes/PMEntitiesCollection.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/PMEntitiesCollection.cs
@@ -159,9 +159,7 @@ namespace Autodesk.ProductInterface.PowerMILL
                 {
                     if (GetByName(basePrefix) != null)
                     {
-                        return _powerMILL
-                            .DoCommandEx("PRINT PAR TERSE \"new_entity_name('" + this[0].Identifier + "','" + basePrefix + "')\"")
-                            .ToString();
+                        return _powerMILL.GetPowerMillParameter("new_entity_name('" + this[0].Identifier + "','" + basePrefix + "')");
                     }
                     return basePrefix;
                 }
@@ -169,7 +167,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             }
             if (Count > 0)
             {
-                return _powerMILL.DoCommandEx("PRINT PAR TERSE \"new_entity_name('" + this[0].Identifier + "')\"").ToString();
+                return _powerMILL.GetPowerMillParameter("new_entity_name('" + this[0].Identifier + "')");
             }
             return "1";
         }
@@ -234,8 +232,7 @@ namespace Autodesk.ProductInterface.PowerMILL
                     return null;
                 }
                 string activeName =
-                    _powerMILL.DoCommandEx("PRINT PAR terse \"entity('" + this[0].Identifier + "','').Name\"")
-                              .ToString();
+                    _powerMILL.GetPowerMillEntityParameter(this[0].Identifier, "", "Name");
                 if (string.IsNullOrEmpty(activeName))
                 {
                     return null;

--- a/Delcam.ProductInterface.PowerMILL/Classes/PMEntity.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/PMEntity.cs
@@ -130,7 +130,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             get
             {
                 string activeName =
-                    PowerMill.DoCommandEx("PRINT PAR terse \"entity('" + Identifier + "','').Name\"").ToString();
+                    PowerMill.GetPowerMillEntityParameter(Identifier, "", "Name");
                 return activeName == Name;
             }
             set
@@ -209,7 +209,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             get
             {
                 return
-                    PowerMill.DoCommandEx("PRINT PAR TERSE \"entity('" + Identifier + "', '" + Name + "').Name\"")
+                    PowerMill.GetPowerMillEntityParameter(Identifier ,  Name ,"Name")
                              .ToString()
                              .Trim() == Name;
             }
@@ -226,7 +226,7 @@ namespace Autodesk.ProductInterface.PowerMILL
         /// <returns>String raw output of the application</returns>
         internal string GetParameter(string paramter)
         {
-            var result = PowerMill.DoCommandEx(string.Format(Resources.GetParameterValue, Identifier, Name, paramter)).ToString();
+            var result = PowerMill.GetPowerMillEntityParameter( Identifier, Name, paramter);
             ValidateOutput(result, paramter);
             return result;
         }

--- a/Delcam.ProductInterface.PowerMILL/Classes/PMFeatureGroupsCollection.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/PMFeatureGroupsCollection.cs
@@ -9,6 +9,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Xml;
 
 namespace Autodesk.ProductInterface.PowerMILL
 {
@@ -52,27 +54,12 @@ namespace Autodesk.ProductInterface.PowerMILL
         /// <returns>The list of the names of all the FeatureGroups in PowerMILL.</returns>
         internal List<string> ReadFeatureGroups()
         {
-            string[] items;
             var names = new List<string>();
-
-            items = ((string) _powerMILL.DoCommandEx("PRINT ENTITY " + PMFeatureGroup.FEATUREGROUP_IDENTIFIER)).Split(
-                new[] {"\r\n"},
-                StringSplitOptions.RemoveEmptyEntries);
-            for (int i = 1; i < items.Length; i++)
+            var featureGroupsXml = _powerMILL.GetPowerMillParameterXML("extract(folder('" + PMFeatureGroup.FEATUREGROUP_IDENTIFIER + "'),'name')").GetElementsByTagName("string");
+            foreach (XmlNode featureGroupNode in featureGroupsXml)
             {
-                var name = "";
-                var index = items[i].IndexOf("'") + 1;
-                if (index > 0)
-                {
-                    name = items[i].Substring(index, items[i].LastIndexOf("'") - index);
-                }
-
-                if (!string.IsNullOrWhiteSpace(name))
-                {
-                    names.Add(name);
-                }
+                names.Add(featureGroupNode.InnerText);
             }
-
             return names;
         }
 

--- a/Delcam.ProductInterface.PowerMILL/Classes/PMGroupsCollection.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/PMGroupsCollection.cs
@@ -9,6 +9,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Xml;
 
 namespace Autodesk.ProductInterface.PowerMILL
 {
@@ -49,24 +50,11 @@ namespace Autodesk.ProductInterface.PowerMILL
         /// <returns>The list of the names of all the Groups in PowerMILL</returns>
         internal List<string> ReadGroups()
         {
-            string[] items = null;
             List<string> names = new List<string>();
-            items = _powerMILL.DoCommandEx("PRINT ENTITY GROUP")
-                              .ToString()
-                              .Split(new[] {Environment.NewLine}, StringSplitOptions.RemoveEmptyEntries);
-            for (int i = 1; i <= items.Length - 1; i++)
+            var groupsXml = _powerMILL.GetPowerMillParameterXML("extract(folder('GROUP'),'name')").GetElementsByTagName("string");
+            foreach (XmlNode groupNode in groupsXml)
             {
-                string name = "";
-                var _with1 = items[i];
-                int index = _with1.IndexOf("'") + 1;
-                if (index > 0)
-                {
-                    name = _with1.Substring(index, _with1.LastIndexOf("'") - index);
-                }
-                if (!string.IsNullOrEmpty(name))
-                {
-                    names.Add(name);
-                }
+                names.Add(groupNode.InnerText);
             }
             return names;
         }

--- a/Delcam.ProductInterface.PowerMILL/Classes/PMLevelOrSet.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/PMLevelOrSet.cs
@@ -90,9 +90,9 @@ namespace Autodesk.ProductInterface.PowerMILL
             get
             {
                 var type = 
-                    PowerMill.DoCommandEx("PRINT PAR terse \"entity('level', '" + Name + "').type\"").ToString();
+                    PowerMill.GetPowerMillEntityParameter("level", Name,"type");
                 var isClamp =
-                    PowerMill.DoCommandEx("PRINT PAR terse \"entity('level', '" + Name + "').isclamp\"").ToString();
+                    PowerMill.GetPowerMillEntityParameter("level", Name, "isclamp");
                 if (isClamp == "1")
                 {
                     return PMLevelOrSetTypes.Clamp;

--- a/Delcam.ProductInterface.PowerMILL/Classes/PMModel.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/PMModel.cs
@@ -92,16 +92,7 @@ namespace Autodesk.ProductInterface.PowerMILL
         {
             get
             {
-                string output = PowerMill.DoCommandEx("PRINT ENTITY PARAMETERS MODEL '" + Name + "'").ToString();
-                foreach (
-                    string value in output.Split(new[] {Environment.NewLine}, StringSplitOptions.RemoveEmptyEntries))
-                {
-                    if (value.Trim().StartsWith("PATH"))
-                    {
-                        return value.Trim().Substring(9);
-                    }
-                }
-                return "";
+                return PowerMill.GetPowerMillEntityParameter("model", Name, "path");
             }
         }
 

--- a/Delcam.ProductInterface.PowerMILL/Classes/PMProject.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/PMProject.cs
@@ -156,7 +156,7 @@ namespace Autodesk.ProductInterface.PowerMILL
                     throw new Exception("This property is not suported in versions earlier than 14");
                 }
                 Directory folder = null;
-                string pmpathTemp = (string) _powerMILL.DoCommandEx("print $project_pathname(false)");
+                string pmpathTemp = _powerMILL.GetPowerMillParameter("project_pathname(false)").Trim();
                 if (!string.IsNullOrWhiteSpace(pmpathTemp))
                 {
                     pmpathTemp = pmpathTemp.Replace(((char) 13).ToString(), string.Empty);
@@ -300,7 +300,7 @@ namespace Autodesk.ProductInterface.PowerMILL
         {
             get
             {
-                string activeName = _powerMILL.DoCommandEx("PRINT PAR terse \"entity('" + PMWorkplane.WORKPLANE_IDENTIFIER + "','').Name\"").ToString();
+                string activeName = _powerMILL.GetPowerMillEntityParameter(PMWorkplane.WORKPLANE_IDENTIFIER , "", "Name");
                 return Workplanes.FirstOrDefault(x => x.Name == activeName);
             }
 
@@ -499,12 +499,12 @@ namespace Autodesk.ProductInterface.PowerMILL
         /// </summary>
         public BoundingBox GetBlockLimits()
         {            
-            var tpBlockXmin = _powerMILL.DoCommandEx("PRINT PAR TERSE $Block.Limits.XMin");
-            var tpBlockXmax = _powerMILL.DoCommandEx("PRINT PAR TERSE $Block.Limits.XMax");
-            var tpBlockYmin = _powerMILL.DoCommandEx("PRINT PAR TERSE $Block.Limits.YMin");
-            var tpBlockYmax = _powerMILL.DoCommandEx("PRINT PAR TERSE $Block.Limits.YMax");
-            var tpBlockZmin = _powerMILL.DoCommandEx("PRINT PAR TERSE $Block.Limits.ZMin");
-            var tpBlockZmax = _powerMILL.DoCommandEx("PRINT PAR TERSE $Block.Limits.ZMax");
+            var tpBlockXmin = _powerMILL.GetPowerMillParameter("Block.Limits.XMin");
+            var tpBlockXmax = _powerMILL.GetPowerMillParameter("Block.Limits.XMax");
+            var tpBlockYmin = _powerMILL.GetPowerMillParameter("Block.Limits.YMin");
+            var tpBlockYmax = _powerMILL.GetPowerMillParameter("Block.Limits.YMax");
+            var tpBlockZmin = _powerMILL.GetPowerMillParameter("Block.Limits.ZMin");
+            var tpBlockZmax = _powerMILL.GetPowerMillParameter("Block.Limits.ZMax");
 
             BoundingBox boundingBox = new BoundingBox(Convert.ToDouble(tpBlockXmin), Convert.ToDouble(tpBlockXmax),
                                                       Convert.ToDouble(tpBlockYmin), Convert.ToDouble(tpBlockYmax),

--- a/Delcam.ProductInterface.PowerMILL/Classes/PMSetup.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/PMSetup.cs
@@ -10,6 +10,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Xml;
 
 namespace Autodesk.ProductInterface.PowerMILL
 {
@@ -58,38 +59,13 @@ namespace Autodesk.ProductInterface.PowerMILL
         {
             get
             {
-                List<PMToolpath> result = new List<PMToolpath>();
-
-                // Get the list of toolpaths that are in the Setup
-                var toolpathsGUIDs = PowerMill.DoCommandEx($"PRINT FOLDER 'Setup\\{Name}'").ToString();
-                // Remove by replacement all CRs
-                toolpathsGUIDs = toolpathsGUIDs.Replace(((char)13).ToString(), string.Empty);
-                // Remove by replacement all prefixes
-                toolpathsGUIDs = toolpathsGUIDs.Replace($"Setup\\{Name}\\\\", string.Empty);
-                // Split the collection by NL
-                var splitToolpathGUIDs = toolpathsGUIDs.Split(new[]{(char)10},StringSplitOptions.RemoveEmptyEntries);
-                // If no toolpaths were contained within the setup, return the empty list
-                if (splitToolpathGUIDs.Length == 0) return result;
-                // Convert to GUIDs to resolve parsing concerns
-                var targetGUIDs = splitToolpathGUIDs.Select(x => new Guid(x));
-
-                // Use the retrieved GUIDs to select from the session's complete toolpath collection.
-                // Iterating in this manor will order the resultant list by the order in which the 
-                // toolpaths appear in the setup
-                try
+                List<PMToolpath> returnToolpaths = new List<PMToolpath>();
+                var toolpathListXML = PowerMill.GetPowerMillParameterXML("components(entity('setup','" + Name + "'))").GetElementsByTagName("Name");
+                foreach (XmlElement toolpathNode in toolpathListXML)
                 {
-                    var setupToolpaths = targetGUIDs
-                        .Select(targetGUID => PowerMill.ActiveProject.Toolpaths
-                            .First(toolpath => toolpath.ID == targetGUID));
-                    result = setupToolpaths.ToList();
+                    returnToolpaths.Add(PowerMill.ActiveProject.Toolpaths.GetByName(toolpathNode.InnerText.Trim()));
                 }
-                catch (InvalidOperationException e)
-                {
-                    throw new Exception(
-                        "Unable to correlate the toolpaths contained within the setup to those of the active project." +
-                        "Consider using the Refresh method on the active project prior to access");
-                }
-                return result;
+                return returnToolpaths;
             }
         }
 

--- a/Delcam.ProductInterface.PowerMILL/Classes/PMSetupsCollection.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/PMSetupsCollection.cs
@@ -9,6 +9,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Xml;
 
 namespace Autodesk.ProductInterface.PowerMILL
 {
@@ -52,27 +53,12 @@ namespace Autodesk.ProductInterface.PowerMILL
         /// <returns>The list of the names of all the Setups in PowerMILL.</returns>
         internal List<string> ReadSetups()
         {
-            string[] items;
             var names = new List<string>();
-
-            items = ((string)_powerMILL.DoCommandEx("PRINT ENTITY " + PMSetup.SETUP_IDENTIFIER)).Split(
-                new[] { "\r\n" },
-                StringSplitOptions.RemoveEmptyEntries);
-            for (int i = 1; i < items.Length; i++)
+            var SetupsXml = _powerMILL.GetPowerMillParameterXML("extract(folder('" + PMSetup.SETUP_IDENTIFIER + "'),'name')").GetElementsByTagName("string");
+            foreach (XmlNode SetupNode in SetupsXml)
             {
-                var name = "";
-                var index = items[i].IndexOf("'") + 1;
-                if (index > 0)
-                {
-                    name = items[i].Substring(index, items[i].LastIndexOf("'") - index);
-                }
-
-                if (!string.IsNullOrWhiteSpace(name))
-                {
-                    names.Add(name);
-                }
+                names.Add(SetupNode.InnerText);
             }
-
             return names;
         }
 

--- a/Delcam.ProductInterface.PowerMILL/Classes/PMStockModel.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/PMStockModel.cs
@@ -9,6 +9,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Xml;
 using Autodesk.Geometry;
 using Autodesk.ProductInterface.Properties;
 
@@ -61,7 +63,7 @@ namespace Autodesk.ProductInterface.PowerMILL
         /// </summary>
         /// <remarks></remarks>
         public void ApplyBlock()
-        {            
+        {
             PowerMill.DoCommand(string.Format("EDIT STOCKMODEL \"{0}\" BLOCK ;", Name));
         }
 
@@ -70,7 +72,7 @@ namespace Autodesk.ProductInterface.PowerMILL
         /// </summary>
         /// <remarks></remarks>
         public void ApplyToolpathFirst()
-        {            
+        {
             PowerMill.DoCommand(string.Format("EDIT STOCKMODEL \"{0}\" INSERT_INPUT TOOLPATH ; FIRST", Name));
         }
 
@@ -88,7 +90,7 @@ namespace Autodesk.ProductInterface.PowerMILL
         /// </summary>
         /// <remarks></remarks>
         public void ApplyToolFirst()
-        {            
+        {
             PowerMill.DoCommand(string.Format("EDIT STOCKMODEL \"{0}\" INSERT_INPUT TOOL ; FIRST", Name));
         }
 
@@ -109,18 +111,11 @@ namespace Autodesk.ProductInterface.PowerMILL
             get
             {
                 // Get the list of states of the StockModel                
-                string stateList = PowerMill.DoCommandEx(string.Format("PRINT PAR \"entity('stockmodel', '{0}').States\"", Name)).ToString();
-                stateList = stateList.Replace(((char)13).ToString(), string.Empty);
-                string[] splitList = stateList.Split((char)10);
-                List<string> returnStates = new List<string>();
-               
-                var startIndex = 0;
-                for (int i = startIndex; i <= splitList.Length - 1; i++)
+                var returnStates = new List<string>();
+                var stateListXml = PowerMill.GetPowerMillParameterXML("extract(entity('stockmodel', '" + Name + "').States,'name')").GetElementsByTagName("Name");
+                foreach (XmlNode state in stateListXml)
                 {
-                    if (splitList[i].Trim().Contains("Name:"))
-                    {
-                        returnStates.Add(splitList[i].Replace("Name: (STRING)", "").Trim());
-                    }
+                    returnStates.Add(state.InnerText.Trim());
                 }
                 return returnStates;
             }
@@ -174,7 +169,7 @@ namespace Autodesk.ProductInterface.PowerMILL
         {
             get
             {
-                string workplane = PowerMill.DoCommandEx(string.Format("PRINT PAR TERSE \"entity('stockmodel', '{0}').Workplane.Name\"", Name)).ToString();                
+                var workplane = PowerMill.GetPowerMillEntityParameter("stockmodel", Name, "Workplane.Name");
                 return PowerMill.ActiveProject.Workplanes.GetByName(workplane);
             }
             set

--- a/Delcam.ProductInterface.PowerMILL/Classes/PMTool.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/PMTool.cs
@@ -68,9 +68,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             {
                 return
                     Convert.ToDouble(
-                        PowerMill.DoCommandEx("PRINT PAR terse \"entity('tool', '" + Name + "').length\"")
-                                 .ToString()
-                                 .Trim());
+                        PowerMill.GetPowerMillEntityParameter("tool", Name, "length").Trim());
             }
             set { PowerMill.DoCommand("EDIT TOOL \"" + Name + "\" LENGTH \"" + value + "\"", "TOOL ACCEPT"); }
         }
@@ -84,9 +82,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             {
                 return
                     Convert.ToInt32(
-                        PowerMill.DoCommandEx("PRINT PAR terse \"entity('tool', '" + Name + "').number\"")
-                                 .ToString()
-                                 .Trim());
+                        PowerMill.GetPowerMillEntityParameter("tool", Name, "number").Trim());
             }
             set { PowerMill.DoCommand("EDIT TOOL \"" + Name + "\" NUMBER " + value, "TOOL ACCEPT"); }
         }
@@ -100,9 +96,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             {
                 return
                     Convert.ToInt32(
-                        PowerMill.DoCommandEx("PRINT PAR terse \"entity('tool', '" + Name + "').flutes\"")
-                                 .ToString()
-                                 .Trim());
+                        PowerMill.GetPowerMillEntityParameter("tool", Name, "flutes").Trim());
             }
             set { PowerMill.DoCommand("EDIT TOOL \"" + Name + "\" NUM_FLUTES \"" + value + "\"", "TOOL ACCEPT"); }
         }
@@ -116,9 +110,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             {
                 return
                     Convert.ToDouble(
-                        PowerMill.DoCommandEx("PRINT PAR terse \"entity('tool', '" + Name + "').diameter\"")
-                                 .ToString()
-                                 .Trim());
+                        PowerMill.GetPowerMillEntityParameter("tool", Name, "diameter").Trim());
             }
             set { PowerMill.DoCommand("EDIT TOOL \"" + Name + "\" DIAMETER \"" + value + "\"", "TOOL ACCEPT"); }
         }
@@ -132,9 +124,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             {
                 return
                     Convert.ToDouble(
-                        PowerMill.DoCommandEx("PRINT PAR terse \"entity('tool', '" + Name + "').overhang\"")
-                                 .ToString()
-                                 .Trim());
+                        PowerMill.GetPowerMillEntityParameter("tool", Name, "overhang").Trim());
             }
             set { PowerMill.DoCommand("EDIT TOOL \"" + Name + "\" OVERHANG " + value, "TOOL ACCEPT"); }
         }
@@ -147,7 +137,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             get
             {
                 return
-                    PowerMill.DoCommandEx("PRINT PAR terse \"entity('tool', '" + Name + "').description\"").ToString();
+                        PowerMill.GetPowerMillEntityParameter("tool", Name, "description").Trim();
             }
             set { PowerMill.DoCommand("EDIT TOOL \"" + Name + "\" DESCRIPTION \"" + value + "\"", "TOOL ACCEPT"); }
         }
@@ -160,7 +150,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             get
             {
                 return
-                    PowerMill.DoCommandEx("PRINT PAR terse \"entity('tool', '" + Name + "').holdername\"").ToString();
+                    PowerMill.GetPowerMillEntityParameter("tool", Name, "holdername").Trim();
             }
             set { PowerMill.DoCommand("EDIT TOOL \"" + Name + "\" HOLDER_NAME \"" + value + "\"", "TOOL ACCEPT"); }
         }
@@ -172,7 +162,7 @@ namespace Autodesk.ProductInterface.PowerMILL
         {
             get
             {
-                switch (PowerMill.DoCommandEx("PRINT PAR terse \"entity('tool', '" + Name + "').coolant\"").ToString()
+                switch (PowerMill.GetPowerMillEntityParameter("tool", Name, "coolant").Trim()
                 )
                 {
                     case "none":
@@ -242,8 +232,7 @@ namespace Autodesk.ProductInterface.PowerMILL
                 }
                 return
                     Convert.ToInt32(
-                        PowerMill.DoCommandEx("PRINT par terse \"size(entity('tool','" + Name + "').shanksetvalues)\"")
-                                 .ToString());
+                        PowerMill.GetPowerMillParameter("size(entity('tool','" + Name + "').shanksetvalues)"));
             }
         }
 
@@ -258,9 +247,8 @@ namespace Autodesk.ProductInterface.PowerMILL
                     "Shank elementes are not available for this version of PowerMILL.  PowerMILL 15 or greater is required");
             }
             string result =
-                PowerMill.DoCommandEx("PRINT par terse \"entity('tool','" + Name + "').shanksetvalues[" + index +
-                                      "].upperdiameter\"").ToString();
-            if (result.Contains("#ERROR"))
+                PowerMill.GetPowerMillEntityParameter("tool", Name, "shanksetvalues[" + index + "].upperdiameter");
+            if (string.IsNullOrWhiteSpace(result) || result.Contains("#ERROR"))
             {
                 throw new IndexOutOfRangeException(
                     "The specified index is greater than the number of elements in the shank");
@@ -279,9 +267,8 @@ namespace Autodesk.ProductInterface.PowerMILL
                     "Shank elementes are not available for this version of PowerMILL.  PowerMILL 15 or greater is required");
             }
             string result =
-                PowerMill.DoCommandEx("PRINT par terse \"entity('tool','" + Name + "').shanksetvalues[" + index +
-                                      "].lowerdiameter\"").ToString();
-            if (result.Contains("#ERROR"))
+                PowerMill.GetPowerMillEntityParameter("tool", Name, "shanksetvalues[" + index + "].lowerdiameter");
+            if (string.IsNullOrWhiteSpace(result) || result.Contains("#ERROR"))
             {
                 throw new IndexOutOfRangeException(
                     "The specified index is greater than the number of elements in the shank");
@@ -300,9 +287,8 @@ namespace Autodesk.ProductInterface.PowerMILL
                     "Shank elementes are not available for this version of PowerMILL.  PowerMILL 15 or greater is required");
             }
             string result =
-                PowerMill.DoCommandEx("PRINT par terse \"entity('tool','" + Name + "').shanksetvalues[" + index +
-                                      "].length\"").ToString();
-            if (result.Contains("#ERROR"))
+                PowerMill.GetPowerMillEntityParameter("tool", Name, "shanksetvalues[" + index + "].length");
+            if (string.IsNullOrWhiteSpace(result) || result.Contains("#ERROR"))
             {
                 throw new IndexOutOfRangeException(
                     "The specified index is greater than the number of elements in the shank");
@@ -324,8 +310,7 @@ namespace Autodesk.ProductInterface.PowerMILL
                 }
                 return
                     Convert.ToInt32(
-                        PowerMill.DoCommandEx("PRINT par terse \"size(entity('tool','" + Name + "').holdersetvalues)\"")
-                                 .ToString());
+                        PowerMill.GetPowerMillParameter("size(entity('tool','" + Name + "').holdersetvalues)"));
             }
         }
 
@@ -340,9 +325,8 @@ namespace Autodesk.ProductInterface.PowerMILL
                     "Holder elements are not available for this version of PowerMILL.  PowerMILL 15 or greater is required");
             }
             string result =
-                PowerMill.DoCommandEx("PRINT par terse \"entity('tool','" + Name + "').holdersetvalues[" + index +
-                                      "].upperdiameter\"").ToString();
-            if (result.Contains("#ERROR"))
+                PowerMill.GetPowerMillEntityParameter("tool", Name, "holdersetvalues[" + index + "].upperdiameter");
+            if (string.IsNullOrWhiteSpace(result) || result.Contains("#ERROR"))
             {
                 throw new IndexOutOfRangeException(
                     "The specified index is greater than the number of elements in the holder");
@@ -361,9 +345,8 @@ namespace Autodesk.ProductInterface.PowerMILL
                     "Holder elementes are not available for this version of PowerMILL.  PowerMILL 15 or greater is required");
             }
             string result =
-                PowerMill.DoCommandEx("PRINT par terse \"entity('tool','" + Name + "').holdersetvalues[" + index +
-                                      "].lowerdiameter\"").ToString();
-            if (result.Contains("#ERROR"))
+                PowerMill.GetPowerMillEntityParameter("tool", Name, "holdersetvalues[" + index + "].lowerdiameter");
+            if (string.IsNullOrWhiteSpace(result) || result.Contains("#ERROR"))
             {
                 throw new IndexOutOfRangeException(
                     "The specified index is greater than the number of elements in the holder");
@@ -382,9 +365,8 @@ namespace Autodesk.ProductInterface.PowerMILL
                     "Holder elementes are not available for this version of PowerMILL.  PowerMILL 15 or greater is required");
             }
             string result =
-                PowerMill.DoCommandEx("PRINT par terse \"entity('tool','" + Name + "').holdersetvalues[" + index +
-                                      "].length\"").ToString();
-            if (result.Contains("#ERROR"))
+                PowerMill.GetPowerMillEntityParameter("tool", Name, "holdersetvalues[" + index + "].length");
+            if (string.IsNullOrWhiteSpace(result) || result.Contains("#ERROR"))
             {
                 throw new IndexOutOfRangeException(
                     "The specified index is greater than the number of elements in the holder");

--- a/Delcam.ProductInterface.PowerMILL/Classes/PMToolpath.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/PMToolpath.cs
@@ -117,12 +117,10 @@ namespace Autodesk.ProductInterface.PowerMILL
                     //uses different method of retrieving toolpath stats.
                     var arcLength =
                         Convert.ToDouble(
-                            PowerMill.DoCommandEx("PRINT PAR terse \"entity('toolpath','" + Name +
-                                                  "').Statistics.CuttingMoves.Lengths.arcs\""));
+                            PowerMill.GetPowerMillEntityParameter("toolpath",Name,"Statistics.CuttingMoves.Lengths.arcs"));
                     var linearLength =
                         Convert.ToDouble(
-                            PowerMill.DoCommandEx("PRINT PAR terse \"entity('toolpath','" + Name +
-                                                  "').Statistics.CuttingMoves.Lengths.Linear\""));
+                            PowerMill.GetPowerMillEntityParameter("toolpath", Name, "Statistics.CuttingMoves.Lengths.Linear"));
                     return arcLength + linearLength;
 
                     // PowerMill 2011 and under 
@@ -457,8 +455,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             get
             {
                 return int.Parse(
-                    PowerMill.DoCommandEx("print par terse ${toolpath_component_count('toolpath', '" + Name + "', 'segments')}")
-                             .ToString());
+                    PowerMill.GetPowerMillParameter("toolpath_component_count('toolpath', '" + Name + "', 'segments')"));
             }
         }
 
@@ -472,8 +469,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             {
                 return
                     (int) double.Parse(
-                        PowerMill.DoCommandEx("print par terse ${segment_point_count(entity('toolpath', '" + Name + "'), " +
-                                              segmentNumber + ")}").ToString());
+                        PowerMill.GetPowerMillParameter("segment_point_count(entity('toolpath', '" + Name + "'), " + segmentNumber + ")"));
             }
             throw new IndexOutOfRangeException(
                 $"{segmentNumber} is greater than the {numberOfSegments} segments in this toolpath.");
@@ -486,8 +482,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             {
                 return
                     double.Parse(
-                        PowerMill.DoCommandEx("print par terse ${segment_get_length(entity('toolpath', '" + Name + "'), " +
-                                              segmentNumber + ")}").ToString());
+                        PowerMill.GetPowerMillParameter("segment_get_length(entity('toolpath', '" + Name + "'), " + segmentNumber + ")"));
             }
             throw new IndexOutOfRangeException(
                 $"{segmentNumber} is greater than the {numberOfSegments} segments in this toolpath.");
@@ -504,15 +499,12 @@ namespace Autodesk.ProductInterface.PowerMILL
             var numberOfPoints = NumberOfPointsInSegment(segmentNumber);
             if (pointNumber < numberOfPoints)
             {
-                var x = double.Parse(PowerMill.DoCommandEx("print par terse ${segment_get_point(entity('toolpath', '" + Name +
-                                                           "'), " +
-                                                           segmentNumber + ", " + pointNumber + ").Position.X}").ToString());
-                var y = double.Parse(PowerMill.DoCommandEx("print par terse ${segment_get_point(entity('toolpath', '" + Name +
-                                                           "'), " +
-                                                           segmentNumber + ", " + pointNumber + ").Position.Y}").ToString());
-                var z = double.Parse(PowerMill.DoCommandEx("print par terse ${segment_get_point(entity('toolpath', '" + Name +
-                                                           "'), " +
-                                                           segmentNumber + ", " + pointNumber + ").Position.Z}").ToString());
+                var x = double.Parse(
+                        PowerMill.GetPowerMillParameter("segment_get_point(entity('toolpath', '" + Name + "'), " + segmentNumber + ", " + pointNumber + ").Position.X"));
+                var y = double.Parse(
+                        PowerMill.GetPowerMillParameter("segment_get_point(entity('toolpath', '" + Name + "'), " + segmentNumber + ", " + pointNumber + ").Position.Y"));
+                var z = double.Parse(
+                        PowerMill.GetPowerMillParameter("segment_get_point(entity('toolpath', '" + Name + "'), " + segmentNumber + ", " + pointNumber + ").Position.Z"));
                 return new Point(x, y, z);
             }
             throw new IndexOutOfRangeException(
@@ -530,15 +522,12 @@ namespace Autodesk.ProductInterface.PowerMILL
             var numberOfPoints = NumberOfPointsInSegment(segmentNumber);
             if (pointNumber < numberOfPoints)
             {
-                var i = double.Parse(PowerMill.DoCommandEx("print par terse ${segment_get_point(entity('toolpath', '" + Name +
-                                                           "'), " +
-                                                           segmentNumber + ", " + pointNumber + ").ToolAxis[0]}").ToString());
-                var j = double.Parse(PowerMill.DoCommandEx("print par terse ${segment_get_point(entity('toolpath', '" + Name +
-                                                           "'), " +
-                                                           segmentNumber + ", " + pointNumber + ").ToolAxis[1]}").ToString());
-                var k = double.Parse(PowerMill.DoCommandEx("print par terse ${segment_get_point(entity('toolpath', '" + Name +
-                                                           "'), " +
-                                                           segmentNumber + ", " + pointNumber + ").ToolAxis[2]}").ToString());
+                var i = double.Parse(
+                        PowerMill.GetPowerMillParameter("segment_get_point(entity('toolpath', '" + Name + "'), " + segmentNumber + ", " + pointNumber + ").ToolAxis[0]"));
+                var j = double.Parse(
+                        PowerMill.GetPowerMillParameter("segment_get_point(entity('toolpath', '" + Name + "'), " + segmentNumber + ", " + pointNumber + ").ToolAxis[1]"));
+                var k = double.Parse(
+                        PowerMill.GetPowerMillParameter("segment_get_point(entity('toolpath', '" + Name + "'), " + segmentNumber + ", " + pointNumber + ").ToolAxis[2]"));
                 return new Vector(i, j, k);
             }
             throw new IndexOutOfRangeException(
@@ -556,18 +545,12 @@ namespace Autodesk.ProductInterface.PowerMILL
             var numberOfPoints = NumberOfPointsInSegment(segmentNumber);
             if (pointNumber < numberOfPoints)
             {
-                var i = double.Parse(PowerMill.DoCommandEx("print par terse ${segment_get_point(entity('toolpath', '" + Name +
-                                                           "'), " +
-                                                           segmentNumber + ", " + pointNumber + ").OrientationVector[0]}")
-                                              .ToString());
-                var j = double.Parse(PowerMill.DoCommandEx("print par terse ${segment_get_point(entity('toolpath', '" + Name +
-                                                           "'), " +
-                                                           segmentNumber + ", " + pointNumber + ").OrientationVector[1]}")
-                                              .ToString());
-                var k = double.Parse(PowerMill.DoCommandEx("print par terse ${segment_get_point(entity('toolpath', '" + Name +
-                                                           "'), " +
-                                                           segmentNumber + ", " + pointNumber + ").OrientationVector[2]}")
-                                              .ToString());
+                var i = double.Parse(
+                        PowerMill.GetPowerMillParameter("segment_get_point(entity('toolpath', '" + Name + "'), " + segmentNumber + ", " + pointNumber + ").OrientationVector[0]"));
+                var j = double.Parse(
+                        PowerMill.GetPowerMillParameter("segment_get_point(entity('toolpath', '" + Name + "'), " + segmentNumber + ", " + pointNumber + ").OrientationVector[1]"));
+                var k = double.Parse(
+                        PowerMill.GetPowerMillParameter("segment_get_point(entity('toolpath', '" + Name + "'), " + segmentNumber + ", " + pointNumber + ").OrientationVector[2]"));
                 return new Vector(i, j, k);
             }
             throw new IndexOutOfRangeException(
@@ -582,8 +565,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             get
             {
                 return int.Parse(
-                    PowerMill.DoCommandEx("print par terse ${toolpath_component_count('toolpath', '" + Name + "', 'leads')}")
-                             .ToString());
+                    PowerMill.GetPowerMillParameter("toolpath_component_count('toolpath', '" + Name + "', 'leads')"));
             }
         }
 
@@ -595,8 +577,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             get
             {
                 return int.Parse(
-                    PowerMill.DoCommandEx("print par terse ${toolpath_component_count('toolpath', '" + Name + "', 'links')}")
-                             .ToString());
+                    PowerMill.GetPowerMillParameter("toolpath_component_count('toolpath', '" + Name + "', 'links')"));
             }
         }
 

--- a/Delcam.ProductInterface.PowerMILL/Classes/PMToolpathsCollection.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/PMToolpathsCollection.cs
@@ -10,6 +10,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Xml;
 
 namespace Autodesk.ProductInterface.PowerMILL
 {
@@ -68,16 +69,13 @@ namespace Autodesk.ProductInterface.PowerMILL
         public void OrderByExplorer()
         {
             // Get the order of toolpaths as per their appearance in the explorer
-            var toolpathsReadout = _powerMILL.DoCommandEx("PRINT FOLDER 'TOOLPATH'").ToString();
-            // Remove by replacement all CRs
-            toolpathsReadout = toolpathsReadout.Replace(((char)13).ToString(), string.Empty);
-            // Split the collection by NL
-            var toolpathPaths = toolpathsReadout.Split((char)10);
-            // Take only the toolpath name element from each path that is not a folder
-            var toolpathOrder = (from toolpathPath in toolpathPaths
-                let toolpathPathSplit = toolpathPath.Split('\\')
-                where toolpathPathSplit.Last() != string.Empty
-                select toolpathPathSplit.Last()).ToList();
+            var toolpathOrder = new List<string>();
+            var toolpathsXml = _powerMILL.GetPowerMillParameterXML("extract(folder('TOOLPATH'),'name')").GetElementsByTagName("string");
+            foreach (XmlNode toolpathNode in toolpathsXml)
+            {
+                toolpathOrder.Add(toolpathNode.InnerText);
+            }
+
             // Take a copy of "this" collection, ordered as per the occurrence of the toolpaths'
             // name in the order list
             var toolpathsOrdered = this.OrderBy(x => toolpathOrder.IndexOf(x.Name)).ToList();

--- a/Delcam.ProductInterface.PowerMILL/Classes/PMWorkplane.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/PMWorkplane.cs
@@ -59,17 +59,12 @@ namespace Autodesk.ProductInterface.PowerMILL
                 return
                     new Geometry.Point(
                         Convert.ToDouble(
-                            PowerMill.DoCommandEx("PRINT PAR terse \"entity('workplane', '" + Name + "').origin.x\"")
-                                     .ToString()
-                                     .Trim()),
+                            PowerMill.GetPowerMillEntityParameter("workplane", Name, "origin.x").Trim()),
                         Convert.ToDouble(
-                            PowerMill.DoCommandEx("PRINT PAR terse \"entity('workplane', '" + Name + "').origin.y\"")
-                                     .ToString()
-                                     .Trim()),
+                            PowerMill.GetPowerMillEntityParameter("workplane", Name, "origin.y").Trim()),
                         Convert.ToDouble(
-                            PowerMill.DoCommandEx("PRINT PAR terse \"entity('workplane', '" + Name + "').origin.z\"")
-                                     .ToString()
-                                     .Trim()));
+                            PowerMill.GetPowerMillEntityParameter("workplane", Name, "origin.y").Trim())
+                        );
             }
         }
 
@@ -83,17 +78,12 @@ namespace Autodesk.ProductInterface.PowerMILL
                 return
                     new Geometry.Vector(
                         Convert.ToDouble(
-                            PowerMill.DoCommandEx("PRINT PAR terse \"entity('workplane', '" + Name + "').Xaxis.x\"")
-                                     .ToString()
-                                     .Trim()),
+                            PowerMill.GetPowerMillEntityParameter("workplane", Name, "Xaxis.x").Trim()),
                         Convert.ToDouble(
-                            PowerMill.DoCommandEx("PRINT PAR terse \"entity('workplane', '" + Name + "').Xaxis.y\"")
-                                     .ToString()
-                                     .Trim()),
+                            PowerMill.GetPowerMillEntityParameter("workplane", Name, "Xaxis.y").Trim()),
                         Convert.ToDouble(
-                            PowerMill.DoCommandEx("PRINT PAR terse \"entity('workplane', '" + Name + "').Xaxis.z\"")
-                                     .ToString()
-                                     .Trim()));
+                            PowerMill.GetPowerMillEntityParameter("workplane", Name, "Xaxis.z").Trim())
+                        );
             }
         }
 
@@ -107,17 +97,12 @@ namespace Autodesk.ProductInterface.PowerMILL
                 return
                     new Geometry.Vector(
                         Convert.ToDouble(
-                            PowerMill.DoCommandEx("PRINT PAR terse \"entity('workplane', '" + Name + "').Yaxis.x\"")
-                                     .ToString()
-                                     .Trim()),
+                            PowerMill.GetPowerMillEntityParameter("workplane", Name, "Yaxis.x").Trim()),
                         Convert.ToDouble(
-                            PowerMill.DoCommandEx("PRINT PAR terse \"entity('workplane', '" + Name + "').Yaxis.y\"")
-                                     .ToString()
-                                     .Trim()),
+                            PowerMill.GetPowerMillEntityParameter("workplane", Name, "Yaxis.y").Trim()),
                         Convert.ToDouble(
-                            PowerMill.DoCommandEx("PRINT PAR terse \"entity('workplane', '" + Name + "').Yaxis.z\"")
-                                     .ToString()
-                                     .Trim()));
+                            PowerMill.GetPowerMillEntityParameter("workplane", Name, "Yaxis.z").Trim())
+                        );
             }
         }
 
@@ -131,17 +116,12 @@ namespace Autodesk.ProductInterface.PowerMILL
                 return
                     new Geometry.Vector(
                         Convert.ToDouble(
-                            PowerMill.DoCommandEx("PRINT PAR terse \"entity('workplane', '" + Name + "').Zaxis.x\"")
-                                     .ToString()
-                                     .Trim()),
+                            PowerMill.GetPowerMillEntityParameter("workplane", Name, "Zaxis.x").Trim()),
                         Convert.ToDouble(
-                            PowerMill.DoCommandEx("PRINT PAR terse \"entity('workplane', '" + Name + "').Zaxis.y\"")
-                                     .ToString()
-                                     .Trim()),
+                            PowerMill.GetPowerMillEntityParameter("workplane", Name, "Zaxis.y").Trim()),
                         Convert.ToDouble(
-                            PowerMill.DoCommandEx("PRINT PAR terse \"entity('workplane', '" + Name + "').Zaxis.z\"")
-                                     .ToString()
-                                     .Trim()));
+                            PowerMill.GetPowerMillEntityParameter("workplane", Name, "Zaxis.z").Trim())
+                        );
             }
         }
 

--- a/Delcam.ProductInterface.PowerMILL/Classes/Tool/PMToolDovetail.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/Tool/PMToolDovetail.cs
@@ -49,7 +49,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             {
                 return
                     Convert.ToDouble(
-                        PowerMill.DoCommandEx("PRINT PAR terse \"entity('tool', '" + Name + "').UpperTipRadius\""));
+                            PowerMill.GetPowerMillEntityParameter("tool", Name, "UpperTipRadius").Trim());
             }
             set { PowerMill.DoCommand("EDIT TOOL \"" + Name + "\" UPPER TIPRADIUS \"" + value + "\"", "TOOL ACCEPT"); }
         }
@@ -63,7 +63,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             {
                 return
                     Convert.ToDouble(
-                        PowerMill.DoCommandEx("PRINT PAR terse \"entity('tool', '" + Name + "').tipradius\""));
+                            PowerMill.GetPowerMillEntityParameter("tool", Name, "tipradius").Trim());
             }
             set { PowerMill.DoCommand("EDIT TOOL \"" + Name + "\" TIPRADIUS \"" + value + "\"", "TOOL ACCEPT"); }
         }
@@ -77,7 +77,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             {
                 return
                     Convert.ToDouble(
-                        PowerMill.DoCommandEx("PRINT PAR terse \"entity('tool', '" + Name + "').taperangle\""));
+                            PowerMill.GetPowerMillEntityParameter("tool", Name, "taperangle").Trim());
             }
             set { PowerMill.DoCommand("EDIT TOOL \"" + Name + "\" TAPERANGLE \"" + value + "\"", "TOOL ACCEPT"); }
         }

--- a/Delcam.ProductInterface.PowerMILL/Classes/Tool/PMToolDrill.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/Tool/PMToolDrill.cs
@@ -49,7 +49,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             {
                 return
                     Convert.ToDouble(
-                        PowerMill.DoCommandEx("PRINT PAR terse \"entity('tool', '" + Name + "').drillangle\""));
+                            PowerMill.GetPowerMillEntityParameter("tool", Name, "drillangle").Trim());
             }
             set { PowerMill.DoCommand("EDIT TOOL \"" + Name + "\" TAPERANGLE \"" + value + "\"", "TOOL ACCEPT"); }
         }

--- a/Delcam.ProductInterface.PowerMILL/Classes/Tool/PMToolEntityFactory.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/Tool/PMToolEntityFactory.cs
@@ -22,7 +22,7 @@ namespace Autodesk.ProductInterface.PowerMILL
         /// <returns>The new tool instance</returns>
         internal static PMTool CreateEntity(PMAutomation powerMILL, string name)
         {
-            var result = powerMILL.DoCommandEx("PRINT PAR terse \"entity('tool', '" + name + "').type\"").ToString().Trim();
+            var result = powerMILL.GetPowerMillEntityParameter("tool", name, "type").Trim();
             switch (result)
             {
                 case "end_mill":

--- a/Delcam.ProductInterface.PowerMILL/Classes/Tool/PMToolTaperedSpherical.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/Tool/PMToolTaperedSpherical.cs
@@ -50,7 +50,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             {
                 return
                     Convert.ToDouble(
-                        PowerMill.DoCommandEx("PRINT PAR terse \"entity('tool', '" + Name + "').tipradius\""));
+                        PowerMill.GetPowerMillEntityParameter("tool", Name, "tipradius").Trim());
             }
             set { PowerMill.DoCommand("EDIT TOOL \"" + Name + "\" TIPRADIUS \"" + value + "\"", "TOOL ACCEPT"); }
         }
@@ -64,7 +64,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             {
                 return
                     Convert.ToDouble(
-                        PowerMill.DoCommandEx("PRINT PAR terse \"entity('tool', '" + Name + "').taperangle\""));
+                        PowerMill.GetPowerMillEntityParameter("tool", Name, "taperangle").Trim());
             }
             set { PowerMill.DoCommand("EDIT TOOL \"" + Name + "\" TAPERANGLE \"" + value + "\"", "TOOL ACCEPT"); }
         }

--- a/Delcam.ProductInterface.PowerMILL/Classes/Tool/PMToolTaperedTipped.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/Tool/PMToolTaperedTipped.cs
@@ -50,7 +50,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             {
                 return
                     Convert.ToDouble(
-                        PowerMill.DoCommandEx("PRINT PAR terse \"entity('tool', '" + Name + "').tipradius\""));
+                        PowerMill.GetPowerMillEntityParameter("tool", Name, "tipradius").Trim());
             }
             set { PowerMill.DoCommand("EDIT TOOL \"" + Name + "\" TIPRADIUS \"" + value + "\"", "TOOL ACCEPT"); }
         }
@@ -64,7 +64,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             {
                 return
                     Convert.ToDouble(
-                        PowerMill.DoCommandEx("PRINT PAR terse \"entity('tool', '" + Name + "').taperangle\""));
+                        PowerMill.GetPowerMillEntityParameter("tool", Name, "taperangle").Trim());
             }
             set { PowerMill.DoCommand("EDIT TOOL \"" + Name + "\" TAPERANGLE \"" + value + "\"", "TOOL ACCEPT"); }
         }
@@ -78,7 +78,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             {
                 return
                     Convert.ToDouble(
-                        PowerMill.DoCommandEx("PRINT PAR terse \"entity('tool', '" + Name + "').taperheight\""));
+                        PowerMill.GetPowerMillEntityParameter("tool", Name, "taperheight").Trim());
             }
             set { PowerMill.DoCommand("EDIT TOOL \"" + Name + "\" TAPERHEIGHT \"" + value + "\"", "TOOL ACCEPT"); }
         }

--- a/Delcam.ProductInterface.PowerMILL/Classes/Tool/PMToolThreadMill.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/Tool/PMToolThreadMill.cs
@@ -49,7 +49,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             get
             {
                 return
-                    Convert.ToDouble(PowerMill.DoCommandEx("PRINT PAR terse \"entity('tool', '" + Name + "').pitch\""));
+                    Convert.ToDouble(PowerMill.GetPowerMillEntityParameter("tool", Name, "pitch").Trim());
             }
             set { PowerMill.DoCommand("EDIT TOOL \"" + Name + "\" PITCH \"" + value + "\"", "TOOL ACCEPT"); }
         }

--- a/Delcam.ProductInterface.PowerMILL/Classes/Tool/PMToolTipRadiused.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/Tool/PMToolTipRadiused.cs
@@ -50,7 +50,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             {
                 return
                     Convert.ToDouble(
-                        PowerMill.DoCommandEx("PRINT PAR terse \"entity('tool', '" + Name + "').tipradius\""));
+                        PowerMill.GetPowerMillEntityParameter("tool", Name, "tipradius").Trim());
             }
             set { PowerMill.DoCommand("EDIT TOOL \"" + Name + "\" TIPRADIUS " + value, "TOOL ACCEPT"); }
         }

--- a/Delcam.ProductInterface.PowerMILL/Classes/Tool/PMToolTippedDisc.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/Tool/PMToolTippedDisc.cs
@@ -50,7 +50,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             {
                 return
                     Convert.ToDouble(
-                        PowerMill.DoCommandEx("PRINT PAR terse \"entity('tool', '" + Name + "').tipradius\""));
+                        PowerMill.GetPowerMillEntityParameter("tool", Name, "tipradius").Trim());
             }
             set { PowerMill.DoCommand("EDIT TOOL \"" + Name + "\" TIPRADIUS \"" + value + "\"", "TOOL ACCEPT"); }
         }
@@ -64,7 +64,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             {
                 return
                     Convert.ToDouble(
-                        PowerMill.DoCommandEx("PRINT PAR terse \"entity('tool', '" + Name + "').tipradius\""));
+                        PowerMill.GetPowerMillEntityParameter("tool", Name, "tipradius").Trim());
             }
             set { PowerMill.DoCommand("EDIT TOOL \"" + Name + "\" TIPRADIUS \"" + value + "\"", "TOOL ACCEPT"); }
         }
@@ -78,7 +78,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             {
                 return
                     Convert.ToDouble(
-                        PowerMill.DoCommandEx("PRINT PAR terse \"entity('tool', '" + Name + "').uppertipradius\""));
+                        PowerMill.GetPowerMillEntityParameter("tool", Name, "uppertipradius").Trim());
             }
             set { PowerMill.DoCommand("EDIT TOOL \"" + Name + "\" UPPER TIPRADIUS \"" + value + "\"", "TOOL ACCEPT"); }
         }

--- a/Delcam.ProductInterface.PowerMILL/Classes/ToolpathStrategies/PMToolpathDrilling.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/ToolpathStrategies/PMToolpathDrilling.cs
@@ -45,9 +45,7 @@ namespace Autodesk.ProductInterface.PowerMILL
             get
             {
                 var drillType =
-                    PowerMill.DoCommandEx("PRINT PAR terse \"entity('toolpath', '" + Name + "').drill.type\"")
-                             .ToString()
-                             .Trim();
+                        PowerMill.GetPowerMillEntityParameter("toolpath", Name, "drill.type").Trim();
                 switch (drillType)
                 {
                     case "single_peck":

--- a/Delcam.ProductInterface.PowerMILL/Classes/ToolpathStrategies/PMToolpathEntityFactory.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/ToolpathStrategies/PMToolpathEntityFactory.cs
@@ -26,9 +26,7 @@ namespace Autodesk.ProductInterface.PowerMILL
         internal static PMToolpath CreateEntity(PMAutomation powerMILL, string name)
         {
             switch (
-                powerMILL.DoCommandEx("PRINT PAR TERSE \"entity('toolpath', '" + name + "').strategy\"")
-                         .ToString()
-                         .Trim())
+                        powerMILL.GetPowerMillEntityParameter("toolpath", name, "strategy").Trim())
             {
                 case "raster":
                     return new PMToolpathRasterFinishing(powerMILL, name);

--- a/Delcam.ProductInterface.PowerMILL/Delcam.ProductInterface.PowerMILL.csproj
+++ b/Delcam.ProductInterface.PowerMILL/Delcam.ProductInterface.PowerMILL.csproj
@@ -80,6 +80,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Classes\Boundary\PMBoundaryBlock.cs" />

--- a/Delcam.ProductInterface.PowerMILL/PMAutomation.cs
+++ b/Delcam.ProductInterface.PowerMILL/PMAutomation.cs
@@ -761,16 +761,16 @@ namespace Autodesk.ProductInterface.PowerMILL
         /// Runs the given command in PowerMILL.  It is a friend version equivalent to ExecuteEx
         /// but does not give the obsolete warning.
         /// </summary>
-        public string GetPowerMillEntityParameter(string pType, string pName, string pParameter)
+        public string GetPowerMillEntityParameter(string pEntityType, string pEntityName, string pParameter)
         {
-            var getParameterString = $"entity('{pType}','{pName}').{pParameter}";
+            var getParameterString = $"entity('{pEntityType}','{pEntityName}').{pParameter}";
             var result = GetPowerMillParameter(getParameterString);
             return result;
         }
 
-        public T GetPowerMillEntityParameter<T>(string pType, string pName, string pParameter) where T: IConvertible
+        public T GetPowerMillEntityParameter<T>(string pEntityType, string pEntityName, string pParameter) where T: IConvertible
         {
-            var getParameterString = $"entity('{pType}','{pName}').{pParameter}";
+            var getParameterString = $"entity('{pEntityType}','{pEntityName}').{pParameter}";
             var result = GetPowerMillParameter<T>(getParameterString);
             return result;
         }

--- a/Delcam.ProductInterface.PowerMILL/PMAutomation.cs
+++ b/Delcam.ProductInterface.PowerMILL/PMAutomation.cs
@@ -9,6 +9,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Xml;
@@ -767,6 +768,13 @@ namespace Autodesk.ProductInterface.PowerMILL
             return result;
         }
 
+        public T GetPowerMillEntityParameter<T>(string pType, string pName, string pParameter) where T: IConvertible
+        {
+            var getParameterString = $"entity('{pType}','{pName}').{pParameter}";
+            var result = GetPowerMillParameter<T>(getParameterString);
+            return result;
+        }
+
         public string GetPowerMillParameter(string getParameterString)
         {
             var xmlResponse = GetPowerMillParameterXML(getParameterString);
@@ -774,6 +782,19 @@ namespace Autodesk.ProductInterface.PowerMILL
             var rootNode = xmlResponse.DocumentElement;
             var result = rootNode.InnerText;
             return result;
+        }
+
+        public T GetPowerMillParameter<T>(string getParameterString) where T: IConvertible
+        {
+            var parameterString = GetPowerMillParameter(getParameterString);
+
+            if (typeof(T) == typeof(bool))
+            {
+                parameterString = parameterString == "1" ? "true" : "false";
+            }
+
+            var converter = TypeDescriptor.GetConverter(typeof(T));
+            return (T)converter.ConvertFromString(parameterString);
         }
 
         public XmlDocument GetPowerMillParameterXML(string getParameterString)


### PR DESCRIPTION
DoCommandEx and ExecuteEx need to use the command window for output and can not be used when PowerMill is busy or in a different mode. Using GetParameterXML to retrive paramters is faster and more relaible.

All Delcam.ProductInterface.PowerMILL.Test Unit tests passed