### PR TITLE
Fix workplane origin Z; add test

### DIFF
--- a/Delcam.ProductInterface.PowerMILL.Test/PMEntityTests/PMWorkplaneTests.cs
+++ b/Delcam.ProductInterface.PowerMILL.Test/PMEntityTests/PMWorkplaneTests.cs
@@ -47,6 +47,20 @@ namespace Autodesk.ProductInterface.PowerMILLTest.PMEntityTests
 
         #region Test properties
 
+        [Test]
+        public void TestOriginProperty()
+        {
+            var workplane = new Geometry.Workplane
+            {
+                Origin = new Geometry.Point(10, 20, 30)
+            };
+            var pmWorkplane = _powerMill.ActiveProject.Workplanes.CreateWorkplane(workplane);
+            Assert.AreEqual(10, pmWorkplane.Origin.X, 1e-6);
+            Assert.AreEqual(20, pmWorkplane.Origin.Y, 1e-6);
+            Assert.AreEqual(30, pmWorkplane.Origin.Z, 1e-6);
+        }
+
+
         #endregion
 
 

--- a/Delcam.ProductInterface.PowerMILL/Classes/PMWorkplane.cs
+++ b/Delcam.ProductInterface.PowerMILL/Classes/PMWorkplane.cs
@@ -63,7 +63,7 @@ namespace Autodesk.ProductInterface.PowerMILL
                         Convert.ToDouble(
                             PowerMill.GetPowerMillEntityParameter("workplane", Name, "origin.y").Trim()),
                         Convert.ToDouble(
-                            PowerMill.GetPowerMillEntityParameter("workplane", Name, "origin.y").Trim())
+                            PowerMill.GetPowerMillEntityParameter("workplane", Name, "origin.z").Trim())
                         );
             }
         }


### PR DESCRIPTION
Issue
PMWorkplane.Origin returns an incorrect Z value (uses the Y component).

Fix
Use the PowerMill parameter origin.z for the Z component.

Scope
Bug fix only; no API or behavior changes beyond correcting the Z value.

Tests
Added unit test:
Autodesk.ProductInterface.PowerMILLTest.PMEntityTests.PMWorkplaneTests.TestOriginProperty

How to run the test

packages/NUnit.ConsoleRunner.3.4.1/tools/nunit3-console.exe \
Delcam.ProductInterface.PowerMILL.Test/bin/Debug/Autodesk.ProductInterface.PowerMILL.Test.dll \
--where "class == Autodesk.ProductInterface.PowerMILLTest.PMEntityTests.PMWorkplaneTests && method == TestOriginProperty"